### PR TITLE
[CIVIS-11444] re-enable lsiown of /config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   docker-linuxserver-ubuntu-fips:
-    image: ${ECR_ACCOUNT_ID:-0123456789012}.dkr.ecr-fips.us-east-1.amazonaws.com/docker-linuxserver-ubuntu-fips:jammy_latest
+    image: ${ECR_ACCOUNT_ID:-0123456789012}.dkr.ecr-fips.us-east-1.amazonaws.com/docker-linuxserver-ubuntu-fips:jammy-latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 ---
 services:
   docker-linuxserver-ubuntu-fips:
-    image: ${ECR_ACCOUNT_ID:-0123456789012}.dkr.ecr-fips.us-east-1.amazonaws.com/docker-linuxserver-ubuntu-fips:latest
-    pull_policy: build
+    image: ${ECR_ACCOUNT_ID:-0123456789012}.dkr.ecr-fips.us-east-1.amazonaws.com/docker-linuxserver-ubuntu-fips:jammy_latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@
 services:
   docker-linuxserver-ubuntu-fips:
     image: ${ECR_ACCOUNT_ID:-0123456789012}.dkr.ecr-fips.us-east-1.amazonaws.com/docker-linuxserver-ubuntu-fips:jammy-latest
+    pull_policy: build
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       platforms:
         - linux/amd64
       args:
+        - PUID=${PUID:-123654}
+        - PGID=${PGID:-123654}
         - BUILD_DATE=${BUILD_DATE:-2025-07-01T00:00:00Z}
         - VERSION=${VERSION:-jammy-22.04}
         - S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-3.1.6.2}

--- a/root/etc/s6-overlay/s6-rc.d/init-adduser/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-adduser/run
@@ -28,5 +28,5 @@ User GID:    $(id -g abc)
 "
 
 lsiown abc:abc /app
-# lsiown abc:abc /config
+lsiown abc:abc /config
 lsiown abc:abc /defaults


### PR DESCRIPTION
## Description

- Now that we have solved the ownership issues, we can reenable lsiown on /config
  - this was previously disabled due to conflicts with AWS EFS's automated uid/gid system that we have no control over. 

- Associated PRs 
  - https://github.com/civisanalytics/docker-code-server/pull/6
  - https://github.com/civisanalytics/civis-vscode/pull/33

## Context, Consequences, & Considerations

Required: Please step through the following list, pausing at each item to consider your change in relation to the item's context.
Check the box to mark that it applies, and enter your relevant notes under the item.

- [ ] Security: This has security implications. This includes (but not limited to) adding users, modifying user/app permissions, network rules/policies, changing a system interconnection, or changing an authorization strategy.
  - [x] This PR does not require security review. These changes are part of a project plan that has already undergone security review. The link is provided below.
  - [ ] This PR requires security review. Add the `security` label to this PR then request a review from the [Security Code Reviewers Team](https://github.com/orgs/civisanalytics/teams/security-code-reviewers).

>

- [ ] Execution: This change requires commands to be run outside of the normal merge.

>

- [ ] Impact: This change may cause service interruptions.

>

- [x] Testing: How did you test this change (unit tests, acceptance tests, etc.)? Did you do any manual testing?

> manual

- [ ] Testing: How will you confirm this change once it's merged?

>

- [ ] Documentation: Documentation to reflect this change has been added to Confluence or Zendesk.

>

- [x] **All items of the checklist have been considered and this PR description is complete.**
